### PR TITLE
change 'apt' with 'apt-get' command

### DIFF
--- a/src/Actions.py
+++ b/src/Actions.py
@@ -19,23 +19,23 @@ def main():
         return True
 
     def install(debianpackage):
-        subprocess.call(["apt", "install", debianpackage, "-yq", "-o", "APT::Status-Fd=2",
+        subprocess.call(["apt-get", "install", debianpackage, "-yq", "-o", "APT::Status-Fd=2",
                          "-o", "Dpkg::Options::=--force-confnew"],
                         env={**os.environ, 'DEBIAN_FRONTEND': 'noninteractive'})
 
     def reinstall(debianpackage):
         subprocess.call(
-            ["apt", "install", "--reinstall", "--allow-downgrades", debianpackage, "-yq", "-o", "APT::Status-Fd=2",
+            ["apt-get", "install", "--reinstall", "--allow-downgrades", debianpackage, "-yq", "-o", "APT::Status-Fd=2",
              "-o", "Dpkg::Options::=--force-confnew"],
             env={**os.environ, 'DEBIAN_FRONTEND': 'noninteractive'})
 
     def remove(packagename):
-        subprocess.call(["apt", "remove", "--purge", packagename, "-yq", "-o", "APT::Status-Fd=2",
+        subprocess.call(["apt-get", "remove", "--purge", packagename, "-yq", "-o", "APT::Status-Fd=2",
                          "-o", "Dpkg::Options::=--force-confnew"],
                         env={**os.environ, 'DEBIAN_FRONTEND': 'noninteractive'})
 
     def downgrade(packagename):
-        subprocess.call(["apt", "install", "--allow-downgrades", packagename, "-yq", "-o", "APT::Status-Fd=2",
+        subprocess.call(["apt-get", "install", "--allow-downgrades", packagename, "-yq", "-o", "APT::Status-Fd=2",
                          "-o", "Dpkg::Options::=--force-confnew"],
                         env={**os.environ, 'DEBIAN_FRONTEND': 'noninteractive'})
 


### PR DESCRIPTION
Use `apt-get` instead of `apt` in back-end. This will resolve the "WARNING: apt does not have a stable CLI interface. Use with caution in scripts." error.

It can be seen in the installation logs or when run in the terminal.

![pardus-apt](https://user-images.githubusercontent.com/93371114/218318588-76e1cdc7-c4ce-46f1-a3ab-0984ba2c4a90.png)
